### PR TITLE
Aperais/cvp2v2

### DIFF
--- a/cvp.h
+++ b/cvp.h
@@ -78,6 +78,19 @@ struct PredictionResult
 	bool speculate = false;
 };
 
+struct mem_data_t
+{
+	bool is_load = false;
+	// For stores
+	uint64_t std_1_lo = 0xdeadbeef;
+	uint64_t std_1_hi = 0xdeadbeef;
+	uint64_t std_2_lo = 0xdeadbeef;
+	uint64_t std_2_hi = 0xdeadbeef;
+	bool is_pair = false;
+	// For stores and loads
+	int access_size = 0;
+};
+
 //
 // getPrediction(const PredictionRequest& req)
 //
@@ -130,6 +143,8 @@ void speculativeUpdate(uint64_t seq_no,    		// dynamic micro-instruction # (sta
 		       uint64_t pc,			
 		       uint64_t next_pc,
 		       InstClass insn,
+			   uint8_t mem_size,
+			   bool is_pair, // Valid only for stores
 		       uint8_t piece,
 		       // Note: up to 3 logical source register specifiers, up to 1 logical destination register specifier.
 		       // 0xdeadbeef means that logical register does not exist.
@@ -153,7 +168,8 @@ void speculativeUpdate(uint64_t seq_no,    		// dynamic micro-instruction # (sta
 extern
 void updatePredictor(uint64_t seq_no,		// dynamic micro-instruction #
 		     uint64_t actual_addr,	// load or store address (0xdeadbeef if not a load or store instruction)
-		     uint64_t actual_value,	// value of destination register (0xdeadbeef if instr. is not eligible for value prediction)
+		     uint64_t actual_value,	// value of destination register (0xdeadbeef if instr. is not eligible for value prediction)/first StData register
+			 const mem_data_t & st_data, // store data if any
 		     uint64_t actual_latency);	// actual execution latency of instruction
 
 //

--- a/lib/cvp.cc
+++ b/lib/cvp.cc
@@ -281,4 +281,5 @@ int main(int argc, char ** argv)
 
   endPredictor();
   sim->output();
+  printf("Misclassify load vector lane: %lu\n", reader.stat_wrongly_ignored_vec_hi);
 }

--- a/lib/uarchsim.h
+++ b/lib/uarchsim.h
@@ -21,8 +21,6 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 // Author: Eric Rotenberg (ericro@ncsu.edu)
 
-
-#include <map>
 #include "spdlog/spdlog.h"
 #include "spdlog/fmt/ostr.h"
 #include "cvp.h"
@@ -40,6 +38,7 @@ struct window_t {
    uint64_t seq_no;
    uint64_t addr;
    uint64_t value;
+   mem_data_t mem_data;
    uint64_t latency;
 };
 
@@ -56,6 +55,13 @@ class uarchsim_t {
 
       // register timestamps
       uint64_t RF[RFSIZE];
+
+      // Register values
+      uint64_t RV[RFSIZE];
+      uint64_t RV_hi[RFSIZE];
+
+      uint64_t RV_EL1[RFSIZE];
+      bool processing_vec_register = false;
 
       // store queue byte timestamps
       map<uint64_t, store_queue_t> SQ;
@@ -98,6 +104,11 @@ class uarchsim_t {
       uint64_t num_load_sqmiss;
 
       uint64_t stat_pfs_issued_to_mem = 0;
+
+      uint64_t stat_misclassified_ldp = 0;
+      uint64_t stat_long_store_pair_misclassify = 0; 
+      uint64_t stat_short_store_pair_misclassify = 0;
+      uint64_t stat_misclassified_str_to_stp = 0;
 
       // Helper for oracle hit/miss information
       uint64_t get_load_exec_cycle(db_t *inst) const;

--- a/lib/uarchsim.h
+++ b/lib/uarchsim.h
@@ -25,6 +25,8 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "spdlog/fmt/ostr.h"
 #include "cvp.h"
 #include "stride_prefetcher.h"
+#include <map>
+
 using namespace std;
 
 #ifndef _RISCV_UARCHSIM_H

--- a/mypredictor.h
+++ b/mypredictor.h
@@ -99,6 +99,10 @@ int HL[NHIST + 1] =
 #define BANKSIZE (1<<LOGBANK)
 #define PREDSIZE (NBBANK*BANKSIZE)
 
+#include <unordered_map>
+
+std::unordered_map<uint64_t, uint8_t> memory;
+
 
 // Global path history
 
@@ -154,6 +158,10 @@ static vtentry Vtage[PREDSIZE];
 static int TICK;		//10 bits // for managing replacement on the VTAGE entries
 static int LastMispVT = 0;	//8 bits //for tracking the last misprediction on VTAGE
 
+uint64_t stat_correct_mem_tracked = 0;
+uint64_t stat_incorrect_mem_tracked_init = 0;
+uint64_t stat_incorrect_mem_tracked_alias = 0;
+uint64_t stat_incorrect_mem_tracked_ld_no_output = 0;
 
  //index function for VTAGE (use the global path history): just a complex hash function
 uint32_t


### PR DESCRIPTION
Fix ARM base-update latency for loads (best effort)
Detect store pair vs store single (best effort)
Fix access size being too large for base update loads, and too small for store pair
Provide store data to value predictor on update (always provide high part of vector regs)